### PR TITLE
Add hive-versions argument to hive-script command

### DIFF
--- a/lib/elasticity/hive_step.rb
+++ b/lib/elasticity/hive_step.rb
@@ -17,7 +17,7 @@ module Elasticity
     end
 
     def to_aws_step(job_flow)
-      args = %w(s3://elasticmapreduce/libs/hive/hive-script --run-hive-script --args)
+      args = %w(s3://elasticmapreduce/libs/hive/hive-script --run-hive-script --base-path s3://elasticmapreduce/libs/hive/ --hive-versions latest --args)
       args.concat(['-f', @script])
       @variables.keys.sort.each do |name|
         args.concat(['-d', "#{name}=#{@variables[name]}"])
@@ -43,11 +43,11 @@ module Elasticity
           :jar => 's3://elasticmapreduce/libs/script-runner/script-runner.jar',
           :args => [
             's3://elasticmapreduce/libs/hive/hive-script',
-              '--base-path',
-              's3://elasticmapreduce/libs/hive/',
-              '--install-hive',
-              '--hive-versions',
-              'latest'
+            '--base-path',
+            's3://elasticmapreduce/libs/hive/',
+            '--install-hive',
+            '--hive-versions',
+            'latest'
           ],
         },
         :name => 'Elasticity - Install Hive'


### PR DESCRIPTION
This solves the issue reported here https://forums.aws.amazon.com/thread.jspa?messageID=350496

The issue is that the hive-script tries to run the wrong version of hive

In log/hadoop/steps/2/stderr I get:

```
sh: /home/hadoop/.versions/hive-0.7.1/bin/hive: No such file or directory
Command exiting with ret '255'
```

Adding in these arguments works around the issue
