### PR TITLE
Add hive-site argument to HiveStep

### DIFF
--- a/lib/elasticity/hive_step.rb
+++ b/lib/elasticity/hive_step.rb
@@ -8,12 +8,14 @@ module Elasticity
     attr_accessor :script
     attr_accessor :variables
     attr_accessor :action_on_failure
+    attr_accessor :hive_site
 
     def initialize(script)
       @name = "Elasticity Hive Step (#{script})"
       @script = script
       @variables = { }
       @action_on_failure = 'TERMINATE_JOB_FLOW'
+      @hive_site = false
     end
 
     def to_aws_step(job_flow)
@@ -37,21 +39,44 @@ module Elasticity
     end
 
     def self.aws_installation_step
-      {
-        :action_on_failure => 'TERMINATE_JOB_FLOW',
-        :hadoop_jar_step => {
-          :jar => 's3://elasticmapreduce/libs/script-runner/script-runner.jar',
-          :args => [
-            's3://elasticmapreduce/libs/hive/hive-script',
-            '--base-path',
-            's3://elasticmapreduce/libs/hive/',
-            '--install-hive',
-            '--hive-versions',
-            'latest'
-          ],
-        },
-        :name => 'Elasticity - Install Hive'
-      }
+      install_steps = [
+        {
+          :action_on_failure => 'TERMINATE_JOB_FLOW',
+          :hadoop_jar_step => {
+            :jar => 's3://elasticmapreduce/libs/script-runner/script-runner.jar',
+            :args => [
+              's3://elasticmapreduce/libs/hive/hive-script',
+              '--base-path',
+              's3://elasticmapreduce/libs/hive/',
+              '--install-hive',
+              '--hive-versions',
+              'latest'
+            ],
+          },
+          :name => 'Elasticity - Install Hive'
+        }
+      ]
+
+      if @hive_site
+        install_steps <<
+          {
+            :action_on_failure => 'TERMINATE_JOB_FLOW',
+            :hadoop_jar_step => {
+              :jar => 's3://elasticmapreduce/libs/script-runner/script-runner.jar',
+              :args => [
+                's3://elasticmapreduce/libs/hive/hive-script',
+                '--install-hive-site',
+                '--hive-site',
+                @hive_site,
+                '--hive-versions',
+                'latest'
+              ],
+            },
+            :name => 'Elasticity - Install Hive Site Configuration',
+          }
+      end
+
+      return install_steps
     end
 
   end

--- a/lib/elasticity/job_flow.rb
+++ b/lib/elasticity/job_flow.rb
@@ -98,9 +98,18 @@ module Elasticity
       if is_jobflow_running?
         jobflow_steps = []
         if jobflow_step.requires_installation? && !@installed_steps.include?(jobflow_step.class)
-          jobflow_steps << jobflow_step.aws_installation_step
+          if jobflow_step.aws_installation_step.kind_of?(Array)
+            jobflow_steps = jobflow_steps | jobflow_step.aws_installation_step
+          else
+            jobflow_steps << jobflow_step.aws_installation_step
+          end
         end
-        jobflow_steps << jobflow_step.to_aws_step(self)
+        newstep = jobflow_step.to_aws_step(self)
+        if newstep.kind_of?(Array)
+          jobflow_steps = jobflow_steps | newstep
+        else
+          jobflow_steps << newstep
+        end
         emr.add_jobflow_steps(@jobflow_id, {:steps => jobflow_steps})
       else
         @jobflow_steps << jobflow_step


### PR DESCRIPTION
This adds the  `--install-hive-site`  and  `--hive-site=file` arguments to HiveStep.

I've had to make job_flow handle arrays, as the installation now can potentially need 2 hadoop steps
