### PR TITLE
Empty Job Flows

### DIFF
--- a/lib/elasticity/job_flow.rb
+++ b/lib/elasticity/job_flow.rb
@@ -110,9 +110,6 @@ module Elasticity
     end
 
     def run
-      if @jobflow_steps.empty?
-        raise JobFlowMissingStepsError, 'Cannot run a job flow without adding steps.  Please use #add_step.'
-      end
       if is_jobflow_running?
         raise JobFlowRunningError, 'Cannot run a job flow multiple times.  To do more with this job flow, please use #add_step.'
       end

--- a/spec/lib/elasticity/job_flow_spec.rb
+++ b/spec/lib/elasticity/job_flow_spec.rb
@@ -440,15 +440,6 @@ describe Elasticity::JobFlow do
 
     end
 
-    context 'when there are no steps added' do
-      let(:jobflow_with_no_steps) { Elasticity::JobFlow.new('_', '_') }
-      it 'should raise an error' do
-        expect {
-          jobflow_with_no_steps.run
-        }.to raise_error(Elasticity::JobFlowMissingStepsError, 'Cannot run a job flow without adding steps.  Please use #add_step.')
-      end
-    end
-
   end
 
   describe '#status' do


### PR DESCRIPTION
In our workflow, we often launch a job flow without having any steps first, adding them in a more interactive fashion. This commit removes the requirement for a job flow to have steps before running it.

I feel like it's more the responsibility of the gem consumer to enforce this anyway, but if it would cause problems for you I'd be happy to just depend on my own fork.
