### PR TITLE
Ensure 'wait_for_completion' does not exit early

### DIFF
--- a/lib/elasticity/job_flow.rb
+++ b/lib/elasticity/job_flow.rb
@@ -168,7 +168,7 @@ module Elasticity
 
     def retry_check
       jf_status = status
-      return status.state == 'RUNNING' || status.state == 'STARTING', jf_status
+      return status.active?, jf_status
     end
 
     def emr

--- a/lib/elasticity/job_flow_status.rb
+++ b/lib/elasticity/job_flow_status.rb
@@ -2,6 +2,9 @@ module Elasticity
 
   class JobFlowStatus
 
+    # http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/ProcessingCycle.html
+    ACTIVE_STATES = %w{RUNNING STARTING BOOTSTRAPPING WAITING SHUTTING_DOWN}
+
     attr_accessor :name
     attr_accessor :jobflow_id
     attr_accessor :state
@@ -23,6 +26,10 @@ module Elasticity
     def initialize
       @steps = []
       @installed_steps = []
+    end
+
+    def active?
+      ACTIVE_STATES.include? state
     end
 
     # Create a jobflow from an AWS <member> (Nokogiri::XML::Element):


### PR DESCRIPTION
Thanks for the great gem!

This PR ensures that `wait_for_completion` accounts for more non-terminal Amazon EMR states, [documented here](http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/ProcessingCycle.html).

I noticed this bug while I was running 3 streaming map reduce steps with `elasticity`, and the `wait_for_completion` loop was exiting on the `BOOTSTRAPPING` action, way before the job finished.
