### PR TITLE
Federated identity security token

### DIFF
--- a/lib/elasticity/aws_request_v4.rb
+++ b/lib/elasticity/aws_request_v4.rb
@@ -23,15 +23,17 @@ module Elasticity
     end
 
     def headers
-      {
+      default_headers = {
         'Authorization' => "AWS4-HMAC-SHA256 Credential=#{@aws_session.access_key}/#{credential_scope}, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date;x-amz-target, Signature=#{aws_v4_signature}",
         'Content-Type' => 'application/x-amz-json-1.1',
         'Host' => host,
         'User-Agent' => "elasticity/#{Elasticity::VERSION}",
         'X-Amz-Content-SHA256' => Digest::SHA256.hexdigest(payload),
         'X-Amz-Date' => @timestamp.strftime('%Y%m%dT%H%M%SZ'),
-        'X-Amz-Target' => "ElasticMapReduce.#{@operation}",
+        'X-Amz-Target' => "ElasticMapReduce.#{@operation}"
       }
+      default_headers.merge!('X-Amz-Security-Token' => @aws_session.security_token) if @aws_session.security_token
+      default_headers
     end
 
     def url

--- a/lib/elasticity/aws_session.rb
+++ b/lib/elasticity/aws_session.rb
@@ -9,6 +9,7 @@ module Elasticity
 
     attr_reader :access_key
     attr_reader :secret_key
+    attr_reader :security_token
     attr_reader :host
     attr_reader :region
 
@@ -25,6 +26,7 @@ module Elasticity
 
       @access_key = get_access_key(access)
       @secret_key = get_secret_key(secret)
+      @security_token = get_security_token
       @host = "elasticmapreduce.#@region.amazonaws.com"
     end
 
@@ -57,6 +59,11 @@ module Elasticity
       return secret if secret
       return ENV['AWS_SECRET_ACCESS_KEY'] if ENV['AWS_SECRET_ACCESS_KEY']
       raise MissingKeyError, 'Please provide a secret key or set AWS_SECRET_ACCESS_KEY.'
+    end
+
+    # TODO refactor the entry point to API to incude security_token
+    def get_security_token
+      ENV['AWS_SECURITY_TOKEN']
     end
 
     # AWS error responses all follow the same form.  Extract the message from

--- a/spec/lib/elasticity/aws_request_v4_spec.rb
+++ b/spec/lib/elasticity/aws_request_v4_spec.rb
@@ -33,6 +33,13 @@ describe Elasticity::AwsRequestV4 do
         'X-Amz-Target' => 'ElasticMapReduce.DescribeJobFlows',
       }
     end
+
+    context 'when security token exists' do
+      it 'adds X-Amz-Security-Token header' do
+        ENV.stub(:[]).with('AWS_SECURITY_TOKEN').and_return('ENV_SECURITY_TOKEN')
+        expect(subject.headers['X-Amz-Security-Token']).to eq('ENV_SECURITY_TOKEN')
+      end
+    end
   end
 
   describe '#payload' do

--- a/spec/lib/elasticity/aws_session_spec.rb
+++ b/spec/lib/elasticity/aws_session_spec.rb
@@ -43,10 +43,11 @@ describe Elasticity::AwsSession do
           before do
             ENV.stub(:[]).with('AWS_ACCESS_KEY_ID').and_return('ENV_ACCESS')
             ENV.stub(:[]).with('AWS_SECRET_ACCESS_KEY').and_return('ENV_SECRET')
+            ENV.stub(:[]).with('AWS_SECURITY_TOKEN')
           end
           it 'should set access and secret keys' do
-            default_values.access_key.should == 'ENV_ACCESS'
-            default_values.secret_key.should == 'ENV_SECRET'
+            expect(default_values.access_key).to eq('ENV_ACCESS')
+            expect(default_values.secret_key).to eq('ENV_SECRET')
           end
         end
 
@@ -55,10 +56,23 @@ describe Elasticity::AwsSession do
           before do
             ENV.stub(:[]).with('AWS_ACCESS_KEY_ID').and_return('ENV_ACCESS')
             ENV.stub(:[]).with('AWS_SECRET_ACCESS_KEY').and_return('ENV_SECRET')
+            ENV.stub(:[]).with('AWS_SECURITY_TOKEN')
           end
           it 'should set access and secret keys' do
-            nil_values.access_key.should == 'ENV_ACCESS'
-            nil_values.secret_key.should == 'ENV_SECRET'
+            expect(nil_values.access_key).to eq('ENV_ACCESS')
+            expect(nil_values.secret_key).to eq('ENV_SECRET')
+          end
+        end
+
+        context 'when security key set' do
+          let(:nil_values) { Elasticity::AwsSession.new(nil, nil) }
+          before do
+            ENV.stub(:[]).with('AWS_ACCESS_KEY_ID').and_return('ENV_ACCESS')
+            ENV.stub(:[]).with('AWS_SECRET_ACCESS_KEY').and_return('ENV_SECRET')
+            ENV.stub(:[]).with('AWS_SECURITY_TOKEN').and_return('ENV_SECURITY_TOKEN')
+          end
+          it 'should set security token' do
+            expect(nil_values.security_token).to eq('ENV_SECURITY_TOKEN')
           end
         end
 
@@ -70,6 +84,7 @@ describe Elasticity::AwsSession do
           before do
             ENV.stub(:[]).with('AWS_ACCESS_KEY_ID').and_return(nil)
             ENV.stub(:[]).with('AWS_SECRET_ACCESS_KEY').and_return('_')
+            ENV.stub(:[]).with('AWS_SECURITY_TOKEN')
           end
           it 'should raise an error' do
             expect {
@@ -81,6 +96,7 @@ describe Elasticity::AwsSession do
           before do
             ENV.stub(:[]).with('AWS_ACCESS_KEY_ID').and_return('_')
             ENV.stub(:[]).with('AWS_SECRET_ACCESS_KEY').and_return(nil)
+            ENV.stub(:[]).with('AWS_SECURITY_TOKEN')
           end
           it 'should raise an error' do
             expect {
@@ -88,8 +104,17 @@ describe Elasticity::AwsSession do
             }.to raise_error(Elasticity::MissingKeyError, 'Please provide a secret key or set AWS_SECRET_ACCESS_KEY.')
           end
         end
+        context 'when the security token is not set' do
+          before do
+            ENV.stub(:[]).with('AWS_ACCESS_KEY_ID').and_return('_')
+            ENV.stub(:[]).with('AWS_SECRET_ACCESS_KEY').and_return('_')
+            ENV.stub(:[]).with('AWS_SECURITY_TOKEN')
+          end
+          it 'should return nothing' do
+            expect(missing_something.security_token).not_to be
+          end
+        end
       end
-
     end
 
   end

--- a/spec/lib/elasticity/emr_spec.rb
+++ b/spec/lib/elasticity/emr_spec.rb
@@ -16,6 +16,7 @@ describe Elasticity::EMR do
       before do
         ENV.stub(:[]).with('AWS_ACCESS_KEY_ID').and_return('ENV_ACCESS')
         ENV.stub(:[]).with('AWS_SECRET_ACCESS_KEY').and_return('ENV_SECRET')
+        ENV.stub(:[]).with('AWS_SECURITY_TOKEN')
       end
       it 'should use environment variables' do
         emr = Elasticity::EMR.new


### PR DESCRIPTION
- [x] ability to pass security token as env var to API for federated accounts
- [x] token is passed via header `X-Amz-Security-Token` when present

Will only work as an env var at the moment I didn't want to change aws_session to handle another argument..

- [x] left a TODO for adding security token as a passed argument for later though