### PR TITLE
Handle steps status that hasn't run yet

### DIFF
--- a/lib/elasticity/cluster_status.rb
+++ b/lib/elasticity/cluster_status.rb
@@ -20,8 +20,8 @@ module Elasticity
         c.cluster_id = cluster_data['Id']
         c.state = cluster_data['Status']['State']
         c.created_at = Time.at(cluster_data['Status']['Timeline']['CreationDateTime'])
-        c.ready_at = Time.at(cluster_data['Status']['Timeline']['ReadyDateTime'])
-        c.ended_at = Time.at(cluster_data['Status']['Timeline']['EndDateTime'])
+        c.ready_at = cluster_data['Status']['Timeline']['ReadyDateTime'] ? Time.at(cluster_data['Status']['Timeline']['ReadyDateTime']) : nil
+        c.ended_at = cluster_data['Status']['Timeline']['EndDateTime'] ? Time.at(cluster_data['Status']['Timeline']['EndDateTime']) : nil
         c.last_state_change_reason = cluster_data['Status']['StateChangeReason']['Code']
         c.master_public_dns_name = cluster_data['MasterPublicDnsName']
         c.normalized_instance_hours = cluster_data['NormalizedInstanceHours']

--- a/lib/elasticity/cluster_step_status.rb
+++ b/lib/elasticity/cluster_step_status.rb
@@ -31,8 +31,8 @@ module Elasticity
           c.state_change_reason = s['Status']['StateChangeReason']['Code']
           c.state_change_reason_message = s['Status']['StateChangeReason']['Message']
           c.created_at = Time.at(s['Status']['Timeline']['CreationDateTime'])
-          c.started_at = Time.at(s['Status']['Timeline']['StartDateTime'])
-          c.ended_at   = Time.at(s['Status']['Timeline']['EndDateTime'])
+          c.started_at = s['Status']['Timeline']['StartDateTime'] ? Time.at(s['Status']['Timeline']['StartDateTime']) : nil
+          c.ended_at   = s['Status']['Timeline']['EndDateTime'] ? Time.at(s['Status']['Timeline']['EndDateTime']) : nil
         end
       end
     end

--- a/lib/elasticity/instance_group.rb
+++ b/lib/elasticity/instance_group.rb
@@ -40,7 +40,7 @@ module Elasticity
       if bid_price < 0
         raise ArgumentError, "The bid price for spot instances should be greater than 0 (#{bid_price} requested)"
       end
-      @bid_price = bid_price
+      @bid_price = "#{bid_price}"
       @market = 'SPOT'
     end
 

--- a/spec/lib/elasticity/cluster_status_spec.rb
+++ b/spec/lib/elasticity/cluster_status_spec.rb
@@ -1,6 +1,16 @@
 describe Elasticity::ClusterStatus do
 
   let(:cluster_state) { 'TERMINATED' }
+  let(:timeline) do
+    <<-JSON
+      {
+        "CreationDateTime": 1436788464.415,
+        "EndDateTime": 1436791032.097,
+        "ReadyDateTime": 1436788842.195
+      }
+    JSON
+  end
+
   let(:aws_cluster_status) do
     <<-JSON
       {
@@ -32,11 +42,7 @@ describe Elasticity::ClusterStatus do
               "Code": "ALL_STEPS_COMPLETED",
               "Message": "Steps completed"
             },
-            "Timeline": {
-              "CreationDateTime": 1436788464.415,
-              "EndDateTime": 1436791032.097,
-              "ReadyDateTime": 1436788842.195
-            }
+            "Timeline": #{timeline}
           },
           "Tags": [
             {
@@ -66,6 +72,21 @@ describe Elasticity::ClusterStatus do
       expect(subject.last_state_change_reason).to eql('ALL_STEPS_COMPLETED')
       expect(subject.master_public_dns_name).to eql('ec2-54-81-173-103.compute-1.amazonaws.com')
       expect(subject.normalized_instance_hours).to eql(2)
+    end
+
+    context 'when cluster is brand new' do
+      let(:timeline) do
+        <<-JSON
+          {
+            "CreationDateTime": 1436788464.415
+          }
+        JSON
+      end
+
+      it 'defaults ready_at and ended_at correctly' do
+        expect(subject.ready_at).not_to be
+        expect(subject.ended_at).not_to be
+      end
     end
   end
 

--- a/spec/lib/elasticity/cluster_step_status_spec.rb
+++ b/spec/lib/elasticity/cluster_step_status_spec.rb
@@ -1,5 +1,15 @@
 describe Elasticity::ClusterStepStatus do
 
+  let(:timeline) do
+    <<-JSON
+      {
+        "CreationDateTime": 1436788464.416,
+        "StartDateTime": 1436788841.237,
+        "EndDateTime": 1436790944.162
+      }
+    JSON
+  end
+
   let(:aws_cluster_steps) do
     <<-JSON
       {
@@ -27,11 +37,7 @@ describe Elasticity::ClusterStepStatus do
                         "Code": "ALL_STEPS_COMPLETED",
                         "Message": "Steps completed"
                       },
-                      "Timeline": {
-                          "CreationDateTime": 1436788464.416,
-                          "EndDateTime": 1436790944.162,
-                          "StartDateTime": 1436788841.237
-                      }
+                      "Timeline": #{timeline}
                   }
               }
           ]
@@ -61,6 +67,22 @@ describe Elasticity::ClusterStepStatus do
       expect(status.created_at).to eql(Time.at(1436788464.416))
       expect(status.started_at).to eql(Time.at(1436788841.237))
       expect(status.ended_at).to eql(Time.at(1436790944.162))
+    end
+
+    context 'newly created step that hasn\'t started yet' do
+      let(:timeline) do
+        <<-JSON
+          {
+            "CreationDateTime": 1436788464.416
+          }
+        JSON
+      end
+
+      it 'sets started_at and ended_at to nil' do
+        status = cluster_step_statuses[0]
+        expect(status.started_at).not_to be
+        expect(status.ended_at).not_to be
+      end
     end
   end
 

--- a/spec/lib/elasticity/instance_group_spec.rb
+++ b/spec/lib/elasticity/instance_group_spec.rb
@@ -74,8 +74,8 @@ describe Elasticity::InstanceGroup do
 
     it 'should set the type and price' do
       subject.set_spot_instances(0.25)
-      subject.market.should == 'SPOT'
-      subject.bid_price.should == 0.25
+      expect(subject.market).to eq('SPOT')
+      expect(subject.bid_price).to eq('0.25')
     end
 
     context 'when the price is <= 0' do
@@ -131,7 +131,7 @@ describe Elasticity::InstanceGroup do
       it 'should generate an AWS config' do
         on_demand_instance_group.to_aws_instance_config.should == {
           :market => 'SPOT',
-          :bid_price => 0.25,
+          :bid_price => '0.25',
           :instance_count => 5,
           :instance_type => 'c1.medium',
           :instance_role => 'CORE',


### PR DESCRIPTION
When a step hasn't run yet the status Timeline from AWS doesn't contain the required dates for:
```
StartDateTime
EndDateTime
```
The changed behavior will just set the attr_accessors for start and end date to nil when the step hasn't run yet.