### PR TITLE
Add job flow steps remove extra steps key

### DIFF
--- a/lib/elasticity/job_flow.rb
+++ b/lib/elasticity/job_flow.rb
@@ -126,7 +126,7 @@ module Elasticity
           jobflow_steps.concat(jobflow_step.aws_installation_steps)
         end
         jobflow_steps << jobflow_step.to_aws_step(self)
-        emr.add_jobflow_steps(@jobflow_id, {:steps => jobflow_steps})
+        emr.add_jobflow_steps(@jobflow_id, jobflow_steps)
       else
         @jobflow_steps << jobflow_step
       end

--- a/spec/lib/elasticity/job_flow_spec.rb
+++ b/spec/lib/elasticity/job_flow_spec.rb
@@ -24,7 +24,7 @@ describe Elasticity::JobFlow do
       expect(subject.service_role).to eql(nil)
     end
   end
-  
+
   describe '#placement=' do
 
     context 'when the placement is set' do
@@ -218,9 +218,7 @@ describe Elasticity::JobFlow do
           let(:additional_step) { Elasticity::PigStep.new('_') }
 
           it 'should submit the step' do
-            emr.should_receive(:add_jobflow_steps).with('RUNNING_JOBFLOW_ID', {
-                :steps => [additional_step.to_aws_step(running_jobflow)]
-              })
+            emr.should_receive(:add_jobflow_steps).with('RUNNING_JOBFLOW_ID', [additional_step.to_aws_step(running_jobflow)])
             running_jobflow.add_step(additional_step)
           end
         end
@@ -229,9 +227,7 @@ describe Elasticity::JobFlow do
           let(:additional_step) { Elasticity::HiveStep.new('_') }
 
           it 'should submit the installation step and the step' do
-            emr.should_receive(:add_jobflow_steps).with('RUNNING_JOBFLOW_ID', {
-                :steps => Elasticity::HiveStep.aws_installation_steps << additional_step.to_aws_step(running_jobflow)
-              })
+            emr.should_receive(:add_jobflow_steps).with('RUNNING_JOBFLOW_ID', Elasticity::HiveStep.aws_installation_steps << additional_step.to_aws_step(running_jobflow))
             running_jobflow.add_step(additional_step)
           end
         end
@@ -243,9 +239,7 @@ describe Elasticity::JobFlow do
         let(:additional_step) { Elasticity::CustomJarStep.new('jar') }
 
         it 'should submit the step' do
-          emr.should_receive(:add_jobflow_steps).with('RUNNING_JOBFLOW_ID', {
-              :steps => [additional_step.to_aws_step(running_jobflow)]
-            })
+          emr.should_receive(:add_jobflow_steps).with('RUNNING_JOBFLOW_ID', [additional_step.to_aws_step(running_jobflow)])
           running_jobflow.add_step(additional_step)
         end
 


### PR DESCRIPTION
- [x] when adding steps to an existing jobflow it doesn't need to pass the steps as a hash.

AWS API error:
```json
{"__type":"SerializationException","Message":"Start of structure or map found where not expected."}
```
This pull request changes:

### Before
```json
{
  "JobFlowId": "****",
  "Steps": {
    "Steps": [
      {
        "ActionOnFailure": "TERMINATE_JOB_FLOW",
        "HadoopJarStep": {
          "Jar": "/home/hadoop/contrib/streaming/hadoop-streaming.jar",
          "Args": [
            "-input",
            "s3://****",
            "-output",
            "s3://****/output/",
            "-mapper",
            "grep -v Date",
            "-reducer",
            "NONE",
            "-jobconf",
            "mapred.output.compress=true",
            "-jobconf",
            "mapred.output.compression.codec=com.hadoop.compression.lzo.LzopCodec"
          ]
        },
        "Name": "Elasticity Streaming Step"
      }
    ]
  }
}
```

### After
```json
{
  "JobFlowId": "****",
  "Steps": [
    {
      "ActionOnFailure": "TERMINATE_JOB_FLOW",
      "HadoopJarStep": {
        "Jar": "/home/hadoop/contrib/streaming/hadoop-streaming.jar",
        "Args": [
          "-input",
          "s3://****/*.gz",
          "-output",
          "s3://****/output/",
          "-mapper",
          "grep -v Date",
          "-reducer",
          "NONE",
          "-jobconf",
          "mapred.output.compress=true",
          "-jobconf",
          "mapred.output.compression.codec=com.hadoop.compression.lzo.LzopCodec"
        ]
      },
      "Name": "Elasticity Streaming Step"
    }
  ]
}
```

Confirmed working with a live cluster