### PR TITLE
Allow tags to be set on runJobFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ jobflow.ami_version                       = 'latest'
 jobflow.log_uri                           = nil
 jobflow.enable_debugging                  = false # Requires a log_uri to enable
 
+jobflow.tags                              = {name: "app-name", department: 'marketing'}
 jobflow.ec2_key_name                      = nil
 jobflow.visible_to_all_users              = false
 jobflow.placement                         = 'us-east-1a'

--- a/lib/elasticity/job_flow.rb
+++ b/lib/elasticity/job_flow.rb
@@ -13,6 +13,7 @@ module Elasticity
     attr_accessor :name
     attr_accessor :instance_count
     attr_accessor :log_uri
+    attr_accessor :tags
     attr_accessor :master_instance_type
     attr_accessor :slave_instance_type
     attr_accessor :ami_version
@@ -186,10 +187,20 @@ module Elasticity
       steps.insert(0, Elasticity::SetupHadoopDebuggingStep.new.to_aws_step(self)) if @enable_debugging
       config[:steps] = steps
       config[:log_uri] = @log_uri if @log_uri
+      config[:tags] = jobflow_tags if @tags
       config[:job_flow_role] = @job_flow_role if @job_flow_role
       config[:service_role] = @service_role if @service_role
       config[:bootstrap_actions] = @bootstrap_actions.map{|a| a.to_aws_bootstrap_action} unless @bootstrap_actions.empty?
       config
+    end
+
+    def jobflow_tags
+      @tags.map do |key, value|
+        {
+          key: key.to_s,
+          value: value
+        }
+      end
     end
 
     def jobflow_preamble

--- a/spec/lib/elasticity/job_flow_spec.rb
+++ b/spec/lib/elasticity/job_flow_spec.rb
@@ -336,6 +336,45 @@ describe Elasticity::JobFlow do
 
     end
 
+    describe 'tags' do
+
+      context 'when a tag is specified' do
+        let(:jobflow_with_tags) do
+          Elasticity::JobFlow.new.tap do |jf|
+            jf.tags = {
+              name: 'app-name',
+              contact: 'admin@example.com'
+            }
+          end
+        end
+        it 'should incorporate it into the jobflow config' do
+          jobflow_with_tags.send(:jobflow_config).should be_a_hash_including(
+            tags: [
+              {
+                key: 'name',
+                value: 'app-name'
+              }, {
+                key: 'contact',
+                value: 'admin@example.com'
+              }
+            ]
+          )
+        end
+      end
+
+      context 'when a tag is not specified' do
+        let(:jobflow_with_no_tags) do
+          Elasticity::JobFlow.new.tap do |jf|
+            jf.tags = nil
+          end
+        end
+        it 'should not make space for it in the jobflow config' do
+          jobflow_with_no_tags.send(:jobflow_config).should_not have_key(:tags)
+        end
+      end
+
+    end
+
     describe 'job flow role' do
 
       context 'when a job flow role is specified' do


### PR DESCRIPTION
- [x] added ability to add tags to jobflow
- [x] changed the DSL for adding tags, as AWS requires a `{key: "name", value: "app-name"}` to be sent. But it nicer to just specify them without being so verbose `{name: 'app-name'}`
- [x] Updated the README to include tagging ability