### PR TITLE
Allow jobflow_id to be accessed after run

### DIFF
--- a/lib/elasticity/job_flow.rb
+++ b/lib/elasticity/job_flow.rb
@@ -25,6 +25,7 @@ module Elasticity
     attr_accessor :enable_debugging
     attr_accessor :job_flow_role
     attr_accessor :service_role
+    attr_accessor :jobflow_id
 
     def initialize
       @action_on_failure = 'TERMINATE_JOB_FLOW'

--- a/spec/lib/elasticity/job_flow_spec.rb
+++ b/spec/lib/elasticity/job_flow_spec.rb
@@ -22,6 +22,7 @@ describe Elasticity::JobFlow do
       expect(subject.enable_debugging).to eql(false)
       expect(subject.job_flow_role).to eql(nil)
       expect(subject.service_role).to eql(nil)
+      expect(subject.jobflow_id).to eql(nil)
     end
   end
 
@@ -589,7 +590,8 @@ describe Elasticity::JobFlow do
 
         it 'should return the jobflow ID' do
           Elasticity::EMR.stub(:new).and_return(emr)
-          jobflow_with_steps.run.should == 'JOBFLOW_ID'
+          expect(jobflow_with_steps.run).to eq('JOBFLOW_ID')
+          expect(jobflow_with_steps.jobflow_id).to eq('JOBFLOW_ID')
         end
 
       end


### PR DESCRIPTION
- [x] added attr_accessor to `JobFlow`

Reason for adding is so that I dont need to store the jobflow id when calling `jobflow.run`. Call it lazy :)

But elasticity should store it for me. I am initializing a class and setting a jobflow as an `attr_reader` on the class. So when other things are happening they need access to the jobflow_id and I dont want to set jobflow_id as well as jobflow itself.

```ruby
    class Mock
      attr_reader :jobflow, :config

      def self.start(config)
        new(config).start
      end

      def initialize(config)
        @config = config
        elasticity_configure
        @jobflow = Elasticity::JobFlow.new
      end
    end
```

That way calling run is just a part of the process and I can use the cluster ID for logging etc without needing to set it in the class.