### PR TITLE
jobflow ids must be passed as an array to AWS

### DIFF
--- a/lib/elasticity/job_flow.rb
+++ b/lib/elasticity/job_flow.rb
@@ -145,7 +145,7 @@ module Elasticity
       if !is_jobflow_running?
         raise JobFlowNotStartedError, 'Cannot #shutdown a job flow that has not yet been #run.'
       end
-      emr.terminate_jobflows(@jobflow_id)
+      emr.terminate_jobflows([@jobflow_id])
     end
 
     def cluster_status

--- a/spec/lib/elasticity/job_flow_spec.rb
+++ b/spec/lib/elasticity/job_flow_spec.rb
@@ -699,7 +699,7 @@ describe Elasticity::JobFlow do
         running_jobflow.run
       end
       it 'should shutdown the running jobflow' do
-        emr.should_receive(:terminate_jobflows).with('JOBFLOW_ID')
+        emr.should_receive(:terminate_jobflows).with(['JOBFLOW_ID'])
         running_jobflow.shutdown
       end
     end


### PR DESCRIPTION
I have tested with a real world cluster and it now works as expected.

See: http://docs.aws.amazon.com/ElasticMapReduce/latest/API/API_TerminateJobFlows.html **JobFlowIds.member.N**