### PR TITLE
Error handling for API rate limiting

### DIFF
--- a/spec/lib/elasticity/aws_session_spec.rb
+++ b/spec/lib/elasticity/aws_session_spec.rb
@@ -94,6 +94,16 @@ describe Elasticity::AwsSession do
           subject.submit({})
         }.to raise_error(ArgumentError, "AWS EMR API Error (#{error_type}): #{error_message}")
       end
+
+      context 'EMR API rate limit hit' do
+        let(:error_type) { 'ThrottlingException' }
+        it 'should raise a Throttling error with the body of the error' do
+          RestClient.should_receive(:post).and_raise(error)
+          expect {
+            subject.submit({})
+          }.to raise_error(Elasticity::ThrottlingException, "AWS EMR API Error (#{error_type}): #{error_message}")
+        end
+      end
     end
 
   end


### PR DESCRIPTION
## Context
Currently A project I am working on is running about 20 EMR clusters that can be running simultaneously(we are working towards using EMR agents) in one account. This is causing throttling errors from the AWS API from within Elasticity.

## Changes
This change aims to allow capture of the API rate limiting error to allow retry.

- [x] handle rate limiting separately
- [ ] allow a custom error class to expose the error type from the response `__type`
- [ ] handle rate limiting with auto retry/expo back off

## Alternatives 
I think what would be better is to have the API error accessible via a custom error proxy instead so users can rescue specific errors by checking the errors `type` attribute. Currently to perform a retry(sleep 30 say) you need to regex the error type out of the error message which is not ideal. If we provided a custom error class that supported an attribute for `type` then it would break existing projects using this gem who are rescuing a `ArgumentError`(not there I imagine there would be many of)

Alternatively I could be a good idea to handle rate limiting from within Elasticity and allow retry's with a max retry attribute possibly.

Let me know what you think would be best or if you need more info.

Cheers