### PR TITLE
AMI 4.x support

### DIFF
--- a/lib/elasticity/job_flow.rb
+++ b/lib/elasticity/job_flow.rb
@@ -28,6 +28,7 @@ module Elasticity
     attr_accessor :service_role
     attr_accessor :jobflow_id
     attr_accessor :aws_applications
+    attr_accessor :additional_info
 
     def initialize
       @action_on_failure = 'TERMINATE_JOB_FLOW'
@@ -201,6 +202,7 @@ module Elasticity
       config[:tags] = jobflow_tags if @tags
       config[:job_flow_role] = @job_flow_role if @job_flow_role
       config[:service_role] = @service_role if @service_role
+      config[:additional_info] = @additional_info if @additional_info
       config[:bootstrap_actions] = @bootstrap_actions.map(&:to_aws_bootstrap_action) unless @bootstrap_actions.empty?
       config[:applications] = @aws_applications.map(&:to_hash) if valid_aws_applications?
       config

--- a/lib/elasticity/s3distcp_step.rb
+++ b/lib/elasticity/s3distcp_step.rb
@@ -2,8 +2,15 @@ module Elasticity
 
   class S3DistCpStep < CustomJarStep
 
-    def initialize
-      super('/home/hadoop/lib/emr-s3distcp-1.0.jar')
+    def initialize(legacy = true)
+      path = if legacy
+      	# For AMI version < 4
+      	'/home/hadoop/lib/emr-s3distcp-1.0.jar'
+      else
+      	# For AMI version >= 4
+      	'/usr/share/aws/emr/s3-dist-cp/lib/s3-dist-cp.jar'
+      end
+      super(path)
       @name = 'Elasticity S3DistCp Step'
     end
 


### PR DESCRIPTION
This PR was created by rebasing https://github.com/rslifka/elasticity/pull/120 onto the master branch, then adding support for the additonal_info field and making the S3DistCpStep work for both the old and the new AMIs.