### PR TITLE
AMI 4.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ jobflow.region                            = 'us-east-1'
 jobflow.instance_count                    = 2
 jobflow.master_instance_type              = 'm1.small'
 jobflow.slave_instance_type               = 'm1.small'
+jobflow.additonal_info                    = 'additonal info'
 ```
 
 ### EMR Applications (optional needs release_label >= 4.0.0)
@@ -334,6 +335,10 @@ copy_step = Elasticity::S3DistCpStep.new
 copy_step.arguments = [...]
 
 jobflow.add_step(copy_step)
+
+# For AMI < 4.x you need to specifify legacy argument
+copy_step = Elasticity::S3DistCpStep.new(true)
+
 ```
 
 ## 7 - Upload Assets (optional)

--- a/lib/elasticity/job_flow.rb
+++ b/lib/elasticity/job_flow.rb
@@ -28,6 +28,7 @@ module Elasticity
     attr_accessor :service_role
     attr_accessor :jobflow_id
     attr_accessor :aws_applications
+    attr_accessor :additional_info
 
     def initialize
       @action_on_failure = 'TERMINATE_JOB_FLOW'
@@ -201,6 +202,7 @@ module Elasticity
       config[:tags] = jobflow_tags if @tags
       config[:job_flow_role] = @job_flow_role if @job_flow_role
       config[:service_role] = @service_role if @service_role
+      config[:additional_info] = @additional_info if @additional_info
       config[:bootstrap_actions] = @bootstrap_actions.map(&:to_aws_bootstrap_action) unless @bootstrap_actions.empty?
       config[:applications] = @aws_applications.map(&:to_hash) if valid_aws_applications?
       config

--- a/lib/elasticity/s3distcp_step.rb
+++ b/lib/elasticity/s3distcp_step.rb
@@ -1,19 +1,10 @@
 module Elasticity
-
   class S3DistCpStep < CustomJarStep
-
-    def initialize(legacy = true)
-      path = if legacy
-      	# For AMI version < 4
-      	'/home/hadoop/lib/emr-s3distcp-1.0.jar'
-      else
-      	# For AMI version >= 4
-      	'/usr/share/aws/emr/s3-dist-cp/lib/s3-dist-cp.jar'
-      end
+    def initialize(legacy = false)
+      path = '/usr/share/aws/emr/s3-dist-cp/lib/s3-dist-cp.jar'
+      path = '/home/hadoop/lib/emr-s3distcp-1.0.jar' if legacy # For AMI version < 4
       super(path)
       @name = 'Elasticity S3DistCp Step'
     end
-
   end
-
 end

--- a/lib/elasticity/s3distcp_step.rb
+++ b/lib/elasticity/s3distcp_step.rb
@@ -2,8 +2,15 @@ module Elasticity
 
   class S3DistCpStep < CustomJarStep
 
-    def initialize
-      super('/home/hadoop/lib/emr-s3distcp-1.0.jar')
+    def initialize(legacy = true)
+      path = if legacy
+      	# For AMI version < 4
+      	'/home/hadoop/lib/emr-s3distcp-1.0.jar'
+      else
+      	# For AMI version >= 4
+      	'/usr/share/aws/emr/s3-dist-cp/lib/s3-dist-cp.jar'
+      end
+      super(path)
       @name = 'Elasticity S3DistCp Step'
     end
 

--- a/spec/lib/elasticity/job_flow_spec.rb
+++ b/spec/lib/elasticity/job_flow_spec.rb
@@ -24,6 +24,7 @@ describe Elasticity::JobFlow do
       expect(subject.enable_debugging).to eql(false)
       expect(subject.job_flow_role).to eql(nil)
       expect(subject.service_role).to eql(nil)
+      expect(subject.additional_info).to eql(nil)
       expect(subject.jobflow_id).to eql(nil)
     end
   end
@@ -61,6 +62,17 @@ describe Elasticity::JobFlow do
       end
     end
 
+  end
+
+  describe '#additional_info=' do
+    context 'when set' do
+      before do
+        subject.additional_info = 'additional info'
+      end
+      it 'additional_info is a string' do
+        expect(subject.additional_info).to eq('additional info')
+      end
+    end
   end
 
   describe '#enable_debugging=' do

--- a/spec/lib/elasticity/s3distcp_step_spec.rb
+++ b/spec/lib/elasticity/s3distcp_step_spec.rb
@@ -6,7 +6,16 @@ describe Elasticity::S3DistCpStep do
 
   it 'should set the appropriate default fields' do
     expect(subject.name).to eql('Elasticity S3DistCp Step')
-    expect(subject.jar).to eql('/home/hadoop/lib/emr-s3distcp-1.0.jar')
+    expect(subject.jar).to eql('/usr/share/aws/emr/s3-dist-cp/lib/s3-dist-cp.jar')
+  end
+
+  context 'legacy' do
+
+    subject { described_class.new(true) }
+
+    it 'sets the correct JAR location' do
+      expect(subject.jar).to eql('/home/hadoop/lib/emr-s3distcp-1.0.jar')
+    end
   end
 
 end


### PR DESCRIPTION
- [x] additional info added
- [x] S3DistCp defaults to new JAR location for AMI >= 4.x