### PR TITLE
Add support for EBS (closes #128)

### DIFF
--- a/lib/elasticity/instance_group.rb
+++ b/lib/elasticity/instance_group.rb
@@ -8,6 +8,7 @@ module Elasticity
     attr_accessor :type
     attr_accessor :role
 
+    attr_reader :ebs_configuration
     attr_reader :bid_price
     attr_reader :market
 
@@ -49,6 +50,12 @@ module Elasticity
       @market = 'ON_DEMAND'
     end
 
+    def set_ebs_configuration(ebs_configuration)
+      if ebs_configuration.is_a?(Elasticity::EbsConfiguration)
+        @ebs_configuration = ebs_configuration
+      end
+    end
+
     def to_aws_instance_config
       {
         :market => @market,
@@ -57,9 +64,64 @@ module Elasticity
         :instance_role => @role,
       }.tap do |config|
         config.merge!(:bid_price => @bid_price) if @market == 'SPOT'
+        config.merge!(:ebs_configuration => @ebs_configuration.to_aws_ebs_config) if @ebs_configuration != nil
       end
     end
 
+  end
+
+  class EbsConfiguration
+
+    attr_accessor :ebs_optimized
+
+    attr_reader :ebs_block_device_configs
+
+    def initialize
+      @ebs_optimized = false
+      @ebs_block_device_configs = Array.new
+    end
+
+    def add_ebs_block_device_config(ebs_block_device_config)
+      if ebs_block_device_config.is_a?(Elasticity::EbsBlockDeviceConfig)
+        @ebs_block_device_configs.push(ebs_block_device_config)
+      end
+    end
+
+    def to_aws_ebs_config
+      {
+        :ebs_optimized => @ebs_optimized,
+        :ebs_block_device_configs => @ebs_block_device_configs.map {
+          |i| i.to_aws_ebs_block_device_config
+        }
+      }
+    end
+  end
+
+  class EbsBlockDeviceConfig
+
+    attr_accessor :volume_type
+    attr_accessor :iops
+    attr_accessor :size_in_gb
+    attr_accessor :volumes_per_instance
+
+    def initialize
+      @volume_type = "gp2"
+      @iops = 1
+      @size_in_gb = 1
+      @volumes_per_instance = 1
+    end
+
+    def to_aws_ebs_block_device_config
+      {
+        :volume_specification => {
+          :volume_type => @volume_type,
+          :size_in_gb => @size_in_gb,
+        }.tap do |spec|
+          spec.merge!(:iops => @iops) if @volume_type == "io1"
+        end,
+        :volumes_per_instance => @volumes_per_instance
+      }
+    end
   end
 
 end

--- a/lib/elasticity/job_flow.rb
+++ b/lib/elasticity/job_flow.rb
@@ -133,6 +133,18 @@ module Elasticity
       @instance_groups[:task] = instance_group
     end
 
+    def set_master_ebs_configuration(ebs_configuration)
+      @instance_groups[:master].set_ebs_configuration(ebs_configuration)
+    end
+
+    def set_core_ebs_configuration(ebs_configuration)
+      @instance_groups[:core].set_ebs_configuration(ebs_configuration)
+    end
+
+    def set_task_ebs_configuration(ebs_configuration)
+      @instance_groups[:task].set_ebs_configuration(ebs_configuration)
+    end
+
     def add_step(jobflow_step)
       if is_jobflow_running?
         jobflow_steps = []


### PR DESCRIPTION
This PR adds the ability to attach EBS configuration options to instance groups which should allow the use of EBS only instance types such as `m4` and `c4`.