### PR TITLE
Fix size_in_gb not being parsed correctly for EBS volumes

### DIFF
--- a/lib/elasticity/instance_group.rb
+++ b/lib/elasticity/instance_group.rb
@@ -115,7 +115,7 @@ module Elasticity
       {
         :volume_specification => {
           :volume_type => @volume_type,
-          :size_in_gb => @size_in_gb,
+          :size_in_g_b => @size_in_gb,
         }.tap do |spec|
           spec.merge!(:iops => @iops) if @volume_type == "io1"
         end,

--- a/spec/lib/elasticity/instance_group_spec.rb
+++ b/spec/lib/elasticity/instance_group_spec.rb
@@ -187,7 +187,7 @@ describe Elasticity::InstanceGroup do
               {
                 :volume_specification => {
                   :volume_type => "gp2",
-                  :size_in_gb => 1,
+                  :size_in_g_b => 1,
                 },
                 :volumes_per_instance => 1
               },
@@ -195,7 +195,7 @@ describe Elasticity::InstanceGroup do
                 :volume_specification => {
                   :volume_type => "io1",
                   :iops => 9999,
-                  :size_in_gb => 10000,
+                  :size_in_g_b => 10000,
                 },
                 :volumes_per_instance => 10
               },


### PR DESCRIPTION
To conform to the AWS API `size_in_gb` needs to be converted to `SizeInGB` not `SizeInGb`.  This change allows the [`camelize`](https://github.com/rslifka/elasticity/blob/master/lib/elasticity/aws_utils.rb#L30-L32) function to produce the correct transformation for this field.

I referenced the ruby documentation rather than the API reference:

http://docs.aws.amazon.com/ElasticMapReduce/latest/API/API_VolumeSpecification.html#EMR-Type-VolumeSpecification-Iops
