### PR TITLE
Make the SetupHadoopDebugging step work everywhere

### DIFF
--- a/lib/elasticity/job_flow.rb
+++ b/lib/elasticity/job_flow.rb
@@ -210,7 +210,7 @@ module Elasticity
       config = jobflow_preamble
       validate_and_apply_ami_or_release_version(config)
       steps = jobflow_steps
-      steps.insert(0, Elasticity::SetupHadoopDebuggingStep.new.to_aws_step(self)) if @enable_debugging
+      steps.insert(0, Elasticity::SetupHadoopDebuggingStep.new(@region).to_aws_step(self)) if @enable_debugging
       config[:steps] = steps
       config[:log_uri] = @log_uri if @log_uri
       config[:tags] = jobflow_tags if @tags

--- a/lib/elasticity/setup_hadoop_debugging_step.rb
+++ b/lib/elasticity/setup_hadoop_debugging_step.rb
@@ -2,10 +2,10 @@ module Elasticity
 
   class SetupHadoopDebuggingStep < CustomJarStep
 
-    def initialize
+    def initialize(region)
       @name = 'Elasticity Setup Hadoop Debugging'
-      @jar = 's3://elasticmapreduce/libs/script-runner/script-runner.jar'
-      @arguments = ['s3://elasticmapreduce/libs/state-pusher/0.1/fetch']
+      @jar = "s3://#{region}.elasticmapreduce/libs/script-runner/script-runner.jar"
+      @arguments = ["s3://#{region}.elasticmapreduce/libs/state-pusher/0.1/fetch"]
       @action_on_failure = 'TERMINATE_JOB_FLOW'
     end
 

--- a/spec/lib/elasticity/job_flow_spec.rb
+++ b/spec/lib/elasticity/job_flow_spec.rb
@@ -312,7 +312,7 @@ describe Elasticity::JobFlow do
         before do
           jobflow_with_steps.log_uri = '_'
           jobflow_with_steps.enable_debugging = true
-          aws_steps.insert(0, Elasticity::SetupHadoopDebuggingStep.new.to_aws_step(jobflow_with_steps))
+          aws_steps.insert(0, Elasticity::SetupHadoopDebuggingStep.new('us-east-1').to_aws_step(jobflow_with_steps))
         end
         it 'should incorporate the step to setup Hadoop debugging' do
           jobflow_with_steps.send(:jobflow_config).should be_a_hash_including({:steps => aws_steps})

--- a/spec/lib/elasticity/setup_hadoop_debugging_step_spec.rb
+++ b/spec/lib/elasticity/setup_hadoop_debugging_step_spec.rb
@@ -1,13 +1,17 @@
 describe Elasticity::SetupHadoopDebuggingStep do
 
+  subject do
+    Elasticity::SetupHadoopDebuggingStep.new('us-east-1')
+  end
+
   it 'should be a CustomJarStep' do
     expect(subject).to be_a(Elasticity::CustomJarStep)
   end
 
   it 'should set the appropriate fields' do
     expect(subject.name).to eql('Elasticity Setup Hadoop Debugging')
-    expect(subject.jar).to eql('s3://elasticmapreduce/libs/script-runner/script-runner.jar')
-    expect(subject.arguments).to eql(['s3://elasticmapreduce/libs/state-pusher/0.1/fetch'])
+    expect(subject.jar).to eql('s3://us-east-1.elasticmapreduce/libs/script-runner/script-runner.jar')
+    expect(subject.arguments).to eql(['s3://us-east-1.elasticmapreduce/libs/state-pusher/0.1/fetch'])
     expect(subject.action_on_failure).to eql('TERMINATE_JOB_FLOW')
   end
 


### PR DESCRIPTION
We've encountered some issues with this step particularly in eu-central-1, prefixing the location of the state pusher with the region solves it.