### PR TITLE
Update fog -> fog-aws dependency

### DIFF
--- a/elasticity.gemspec
+++ b/elasticity.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description           = %q{Streamlined, programmatic access to Amazon's Elastic Map Reduce service, driven by the Sharethrough team's requirements for belting out EMR jobs.}
 
   s.add_dependency('rest-client', '~> 1.0')
-  s.add_dependency('fog', '~> 1.0')
+  s.add_dependency('fog-aws', '~> 1.0')
   s.add_dependency('unf', '~> 0.1')
 
   s.add_development_dependency('factory_girl', '~> 4.0')

--- a/lib/elasticity.rb
+++ b/lib/elasticity.rb
@@ -3,7 +3,7 @@ require 'time'
 
 require 'rest_client'
 require 'nokogiri'
-require 'fog'
+require 'fog/aws'
 
 require 'elasticity/version'
 


### PR DESCRIPTION
Since the latest versions of fog split their gems based on the cloud provider, this PR will avoid having the gems depending on elasticity retrieve all fog-related gems.