### PR TITLE
Use Request.execute to make HTTP requests

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
+## 6.0.14 - January 18, 2019
+
+- Including PR [#142](https://github.com/rslifka/elasticity/pull/142) - "Use Request.execute to make HTTP requests". Thank you [@BenFradet ](https://github.com/BenFradet )!
+
 ## 6.0.13 - January 17, 2019
 
-- Including PR [#141](https://github.com/rslifka/elasticity/pull/140) - "Add the ability to customize timeouts ". Thank you [@BenFradet ](https://github.com/BenFradet )!
+- Including PR [#141](https://github.com/rslifka/elasticity/pull/141) - "Add the ability to customize timeouts". Thank you [@BenFradet ](https://github.com/BenFradet )!
 
 ## 6.0.12 - February 7, 2017
 

--- a/lib/elasticity/aws_session.rb
+++ b/lib/elasticity/aws_session.rb
@@ -31,7 +31,7 @@ module Elasticity
     def submit(ruby_service_hash)
       aws_request = AwsRequestV4.new(self, ruby_service_hash)
       begin
-        RestClient.execute(
+        RestClient::Request.execute(
           :method => :post,
           :url => aws_request.url,
           :payload => aws_request.payload,

--- a/lib/elasticity/version.rb
+++ b/lib/elasticity/version.rb
@@ -1,3 +1,3 @@
 module Elasticity
-  VERSION = '6.0.13'
+  VERSION = '6.0.14'
 end

--- a/spec/lib/elasticity/aws_request_v4_spec.rb
+++ b/spec/lib/elasticity/aws_request_v4_spec.rb
@@ -144,7 +144,7 @@ describe Elasticity::AwsRequestV4 do
 
   describe '.aws_v4_signature' do
     it 'should create the proper signature' do
-      subject.send(:aws_v4_signature).should == '86798537f9f4310015aac337d493c4b4abb5113109e04a9898c845d09d2d8bdf'
+      subject.send(:aws_v4_signature).should == '121479f023ad04263baf24fd358aa5bf07bcb75b2ed108cea3d72cb52cc2e8f0'
     end
   end
 

--- a/spec/lib/elasticity/aws_session_spec.rb
+++ b/spec/lib/elasticity/aws_session_spec.rb
@@ -14,7 +14,6 @@ describe Elasticity::AwsSession do
   end
 
   describe '#initialize' do
-
     context 'when access and/or secret keys are provided' do
       it 'should set them to the provided values' do
         subject.region.should == 'us-east-1'
@@ -75,14 +74,14 @@ describe Elasticity::AwsSession do
         @request = Elasticity::AwsRequestV4.new(subject, {})
         @request.should_receive(:url).and_return('TEST_URL')
         @request.should_receive(:payload).and_return('TEST_PAYLOAD')
-        @request.should_receive(:headers).and_return('TEST_HEADERS')
+        @request.should_receive(:headers).and_return({:header => 'TEST_HEADERS'})
 
         Elasticity::AwsRequestV4.should_receive(:new).with(subject, {}).and_return(@request)
-        RestClient.should_receive(:execute).with(
+        RestClient::Request.should_receive(:execute).with(
           :method => :post,
           :url => 'TEST_URL',
           :payload => 'TEST_PAYLOAD',
-          :headers => 'TEST_HEADERS',
+          :headers => {:header => 'TEST_HEADERS'},
           :timeout => 60
         )
       end
@@ -107,7 +106,7 @@ describe Elasticity::AwsSession do
       end
 
       it 'should raise an Argument error with the body of the error' do
-        RestClient.should_receive(:execute).and_raise(error)
+        RestClient::Request.should_receive(:execute).and_raise(error)
         expect {
           subject.submit({})
         }.to raise_error(ArgumentError, "AWS EMR API Error (#{error_type}): #{error_message}")
@@ -116,7 +115,7 @@ describe Elasticity::AwsSession do
       context 'EMR API rate limit hit' do
         let(:error_type) { 'ThrottlingException' }
         it 'should raise a Throttling error with the body of the error' do
-          RestClient.should_receive(:execute).and_raise(error)
+          RestClient::Request.should_receive(:execute).and_raise(error)
           expect {
             subject.submit({})
           }.to raise_error(Elasticity::ThrottlingException, "AWS EMR API Error (#{error_type}): #{error_message}")


### PR DESCRIPTION
Turns out it's `RestClient::Request.execute` and not `RestClient.execute`, sorry.